### PR TITLE
Add signature in SAML request for service provider authentication at …

### DIFF
--- a/example_config/etc/nginx/lua/init.lua
+++ b/example_config/etc/nginx/lua/init.lua
@@ -3,6 +3,7 @@
 local xmlsec = require "saml.service_provider.xmlsec"
 local config = require "saml.service_provider.config"
 config.response.idp_certificate = xmlsec.readfile('/etc/nginx/saml/idp.example.com.crt')
+config.request.sp_private_key = xmlsec.readfile('/etc/ssl/private/sp.example.com.key')
 xmlsec.load_xsd_files('/etc/nginx/saml')
 
 end)()

--- a/lib/saml/service_provider.lua
+++ b/lib/saml/service_provider.lua
@@ -140,6 +140,7 @@ function _M.redirect_to_login(self)
         idp_dest_url = req_cfg.idp_dest_url,
         sp_entity_id = req_cfg.sp_entity_id,
         sp_saml_finish_url = req_cfg.sp_saml_finish_url,
+        sp_private_key = req_cfg.sp_private_key,
     })
     return req:redirect_to_idp_to_login()
 end


### PR DESCRIPTION
…IdPs

An IdP can authenticate a service provider when a signature is included in SAMLRequest. However, current nginx-lua-saml-service-provider does not include it and IdP cannot authenticate the signature in SAMLRequest. This patch adds the signature to SAMLRequest.
A private key file for the signature is specified by "config.request.sp_private_key" in init.lua. Note that this patch supports only RSA-SHA256 as a signature algorithm.